### PR TITLE
add select_ca option to mdau_to_pos_arr

### DIFF
--- a/src/cryoER/tools.py
+++ b/src/cryoER/tools.py
@@ -1,18 +1,18 @@
 import torch
 import MDAnalysis as mda
 
-def mdau_to_pos_arr(u, frame_cluster = None):
-    protein_CA = u.select_atoms("protein and name CA")
+def mdau_to_pos_arr(u, frame_cluster=None, select_ca=True):
+    atoms = u.select_atoms("protein and name CA") if select_ca else u.atoms
     if frame_cluster is None:
         n_frame = len(u.trajectory)
     else:
         n_frame = len(frame_cluster)
-    pos = torch.zeros((n_frame, len(protein_CA), 3), dtype=float)
+    pos = torch.zeros((n_frame, len(atoms), 3), dtype=float)
     if frame_cluster is None:
         for i, ts in enumerate(u.trajectory):
-            pos[i] = torch.from_numpy(protein_CA.positions)
+            pos[i] = torch.from_numpy(atoms.positions)
     else:
         for i, ts in enumerate(u.trajectory[frame_cluster]):
-            pos[i] = torch.from_numpy(protein_CA.positions)
+            pos[i] = torch.from_numpy(atoms.positions)
     pos -= pos.mean(1).unsqueeze(1)
     return pos


### PR DESCRIPTION
I think this is a useful option to have to make this function more generally usable.

The default behaviour is still as before, selecting the 10 CA atoms:
```
Python 3.9.18 (main, Sep 11 2023, 13:41:44) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.15.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: >>> import MDAnalysis as mda
   ...: >>> top_image = "data/image.pdb"
   ...: >>> traj_image = "data/image.xtc"
   ...: >>> uImg = mda.Universe(top_image, traj_image)

In [2]: >>> from cryoER.tools import mdau_to_pos_arr
   ...: >>> coord_img = mdau_to_pos_arr(uImg)

In [3]: coord_img.shape
Out[3]: torch.Size([5277, 10, 3])
```

The new behaviour is to use all atoms:
```
In [4]: >>> from cryoER.tools import mdau_to_pos_arr
   ...: >>> coord_img = mdau_to_pos_arr(uImg, select_ca=False)

In [5]: coord_img.shape
Out[5]: torch.Size([5277, 138, 3])
```