### PR TITLE
init prior counts weights as floats

### DIFF
--- a/src/cryoER/run_cryoER_mcmc.py
+++ b/src/cryoER/run_cryoER_mcmc.py
@@ -128,9 +128,7 @@ def run_cryoER_mcmc(
 ):
 
     ## Read N_m, the number of conformations that are in the mth cluster
-    infileclustersize = infileclustersize
-    counts = np.loadtxt(infileclustersize).astype(int)
-    counts = counts.astype(float)
+    counts = np.loadtxt(infileclustersize).astype(float)
     counts /= np.sum(counts)
     log_Nm = np.log(counts)
 


### PR DESCRIPTION
This won't break anything if inputs are ints, but permits them to not be.