### PR TITLE
avoid norm with lmbd -1

### DIFF
--- a/src/cryoER/run_cryoER_mcmc.py
+++ b/src/cryoER/run_cryoER_mcmc.py
@@ -162,7 +162,10 @@ def run_cryoER_mcmc(
     json_filename = "%s/Dmat.json" % (outdir)
     stan_output_file = "%s/Stan_output" % (outdir)
 
-    norm = 0.5 / (lmbd**2)
+    if lmbd == -1:
+        norm = 1
+    else:
+        norm = 0.5 / (lmbd**2)
     Dmat = -norm * distance.T
 
     dictionary = {


### PR DESCRIPTION
This allows us to use pre-calculated log likelihood by giving an unreasonable lambda of -1 that is a common default in scipion