### PR TITLE
fix dummy norm sign

### DIFF
--- a/src/cryoER/run_cryoER_mcmc.py
+++ b/src/cryoER/run_cryoER_mcmc.py
@@ -161,7 +161,7 @@ def run_cryoER_mcmc(
     stan_output_file = "%s/Stan_output" % (outdir)
 
     if lmbd == -1:
-        norm = 1
+        norm = -1
     else:
         norm = 0.5 / (lmbd**2)
     Dmat = -norm * distance.T


### PR DESCRIPTION
When scipion provides a lambda of -1 because the input is already the log likelihood not the distance and it doesn't need normalisation, we should then give a norm of -1 so -norm is 1.